### PR TITLE
[FEAT] #1 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,24 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Security (소셜 로그인 관련 의존성)
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.2'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.2'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.2'
+
+    // OAuth 2.0
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // Spring Boot DevTools (개발 시 편의성 제공)
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/be/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/be/apiPayload/code/status/ErrorStatus.java
@@ -18,41 +18,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    //유저 관련 응답
-    _NOT_EXIST_USER(HttpStatus.NOT_FOUND, "USER501", "존재하지 않는 유저 아이디입니다"),
-    _SAME_EMAIL(HttpStatus.NOT_FOUND, "USER501", "이미 존재하는 이메일 입니다."),
-    _NOT_EXIST_EMAIL(HttpStatus.NOT_FOUND, "USER502", "존재하지 않는 이메일 입니다."),
-    _NOT_MATCH_PASSWORD(HttpStatus.NOT_FOUND, "USER503", "비밀번호가 틀렸습니다."),
-    
-    //JWT 관련 응답
-    _INVALID_JWT(HttpStatus.UNAUTHORIZED, "JWT401", "유효하지 않은 JWT 토큰입니다."),
-    _EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "JWT402", "액세스 토큰이 만료되었습니다."),
-    _UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "JWT403", "지원되지 않는 JWT 토큰입니다."),
-    _EMPTY_JWT(HttpStatus.UNAUTHORIZED, "JWT404", "JWT 토큰이 비어 있습니다."),
-    _EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "JWT405", "리프레쉬토큰이 만료되었거나, 없습니다. 로그인을 진행해주세요."),
-    _REFRESHED_ACCESS_TOKEN(HttpStatus.valueOf(419), "JWT406", "AccessToken이 재발급되었습니다. 요청을 다시 보내주세요."),
+    //로그인 관련 에러
+    _NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER401", "해당 유저를 찾을 수 없습니다.")
 
-    //소셜로그인 관련 응답
-    _INVALID_SOCIAL_LOGIN(HttpStatus.UNAUTHORIZED, "SOCIAL401", "지원하지 않는 소셜로그인 입니다."),
-
-    //토큰 관련 응답
-    _NOT_EXIST_TOKEN_TYPE(HttpStatus.NOT_FOUND, "TOKEN501", "존재하지 않는 토큰 타입입니다"),
-
-    //채팅 관련 응답
-    _NOT_EXIST_CHAT(HttpStatus.NOT_FOUND, "CHAT501", "존재하지 않는 채팅방 아이디입니다"),
-    _NOT_MATCH_CHAT(HttpStatus.NOT_FOUND, "CHAT502", "사용할 수 없는 채팅방입니다."),
-    _INVALID_AI_TYPE(HttpStatus.NOT_FOUND, "CHAT503", "유효하지 않은 AI 타입입니다."),
-
-    //AI 관련 응답
-    _NOT_EXIST_TOKEN(HttpStatus.NOT_FOUND, "AI501", "토큰을 보유하고 있지 않습니다"),
-    _BARD_CONNECT_FAIL(HttpStatus.BAD_REQUEST, "AI502", "Bard 응답 요청 중 에러가 발생했습니다"),
-    _BARD_RESPONSE_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "AI503", "Bard 응답값이 비어있습니다"),
-    _GPT_CONNECT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AI504", "GPT 응답 요청 중 에러가 발생했습니다"),
-    _GPT_RESPONSE_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "AI504", "GPT 응답값이 비어있습니다"),
-    _CLAUDE_CONNECT_FAIL(HttpStatus.BAD_REQUEST, "AI505", "CLAUDE 응답 요청 중 에러가 발생했습니다"),
-    _CLAUDE_RESPONSE_NULL(HttpStatus.BAD_REQUEST, "AI505", "CLAUDE 응답값이 비어있습니다"),
-    _DEEPSEEK_CONNECT_FAIL(HttpStatus.BAD_REQUEST, "AI505", "DeepSeek 응답 요청 중 에러가 발생했습니다"),
-    _DEEPSEEK_RESPONSE_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "AI506", "DeepSeek 응답값이 비어있습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/be/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/be/apiPayload/code/status/SuccessStatus.java
@@ -12,7 +12,10 @@ import org.springframework.http.HttpStatus;
 public enum SuccessStatus implements BaseCode {
 
     //일반적 응답
-    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+    _CREATED_ACCESS_TOKEN(HttpStatus.CREATED, "201", "액세스 토큰 재발행에 성공했습니다."),
+
+            ;
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/example/be/apiPayload/exception/handler/OAuthLoginFailureHandler.java
+++ b/src/main/java/com/example/be/apiPayload/exception/handler/OAuthLoginFailureHandler.java
@@ -1,0 +1,24 @@
+package com.example.be.apiPayload.exception.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuthLoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        log.error("LOGIN FAILED : {}", exception.getMessage());
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/src/main/java/com/example/be/apiPayload/exception/handler/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/example/be/apiPayload/exception/handler/OAuthLoginSuccessHandler.java
@@ -1,0 +1,118 @@
+package com.example.be.apiPayload.exception.handler;
+
+import com.example.be.config.provider.GoogleUserInfo;
+import com.example.be.config.provider.KakaoUserInfo;
+import com.example.be.config.provider.NaverUserInfo;
+import com.example.be.config.provider.OAuth2UserInfo;
+import com.example.be.domain.RefreshToken;
+import com.example.be.domain.User;
+import com.example.be.repository.RefreshTokenRepository;
+import com.example.be.repository.UserRepository;
+import com.example.be.service.JwtUtilServiceImpl;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    @Value("${jwt.redirect}")
+    private String REDIRECT_URI; // 프론트엔드로 Jwt 토큰을 리다이렉트할 URI
+
+    @Value("${jwt.access-token.expiration-time}")
+    private long ACCESS_TOKEN_EXPIRATION_TIME; // 액세스 토큰 유효기간
+
+    @Value("${jwt.refresh-token.expiration-time}")
+    private long REFRESH_TOKEN_EXPIRATION_TIME; // 리프레쉬 토큰 유효기간
+
+    private OAuth2UserInfo oAuth2UserInfo = null;
+
+    private final JwtUtilServiceImpl jwtUtil;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication; // 토큰
+        final String provider = token.getAuthorizedClientRegistrationId(); // provider 추출
+
+        // 구글 || 카카오 || 네이버 로그인 요청
+        switch (provider) {
+            case "google" -> {
+                log.info("구글 로그인 요청");
+                oAuth2UserInfo = new GoogleUserInfo(token.getPrincipal().getAttributes());
+            }
+            case "kakao" -> {
+                log.info("카카오 로그인 요청");
+                oAuth2UserInfo = new KakaoUserInfo(token.getPrincipal().getAttributes());
+            }
+            case "naver" -> {
+                log.info("네이버 로그인 요청");
+                oAuth2UserInfo = new NaverUserInfo((Map<String, Object>) token.getPrincipal().getAttributes().get("response"));
+            }
+        }
+
+        // 정보 추출
+        String providerId = oAuth2UserInfo.getProviderId();
+        String name = oAuth2UserInfo.getName();
+        String email = oAuth2UserInfo.getEmail();
+
+        User existUser = userRepository.findByProviderId(providerId);
+        User user;
+
+        if (existUser == null) {
+            // 신규 유저인 경우
+            log.info("신규 유저입니다. 등록을 진행합니다.");
+
+            user = User.builder()
+                    .userId(UUID.randomUUID())
+                    .email(email)
+                    .name(name)
+                    .createDate(LocalDateTime.now())
+                    .provider(provider)
+                    .providerId(providerId)
+                    .build();
+            userRepository.save(user);
+        } else {
+            // 기존 유저인 경우
+            log.info("기존 유저입니다.");
+            refreshTokenRepository.deleteByUserId(existUser.getUserId());
+            user = existUser;
+        }
+
+        log.info("유저 이름 : {}", name);
+        log.info("PROVIDER : {}", provider);
+        log.info("PROVIDER_ID : {}", providerId);
+
+        // 리프레쉬 토큰 발급 후 저장
+        String refreshToken = jwtUtil.generateRefreshToken(user.getUserId(), REFRESH_TOKEN_EXPIRATION_TIME);
+
+        RefreshToken newRefreshToken = RefreshToken.builder()
+                .userId(user.getUserId())
+                .token(refreshToken)
+                .build();
+
+        refreshTokenRepository.save(newRefreshToken);
+
+        // 액세스 토큰 발급
+        String accessToken = jwtUtil.generateAccessToken(user.getUserId(), ACCESS_TOKEN_EXPIRATION_TIME);
+
+        // 이름, 액세스 토큰, 리프레쉬 토큰을 담아 리다이렉트
+        String encodedName = URLEncoder.encode(name, "UTF-8");
+        String redirectUri = String.format(REDIRECT_URI, encodedName, accessToken, refreshToken);
+        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+    }
+}

--- a/src/main/java/com/example/be/apiPayload/exception/handler/UserHandler.java
+++ b/src/main/java/com/example/be/apiPayload/exception/handler/UserHandler.java
@@ -1,0 +1,10 @@
+package com.example.be.apiPayload.exception.handler;
+
+import com.example.be.apiPayload.code.BaseErrorCode;
+import com.example.be.apiPayload.exception.GeneralException;
+
+public class UserHandler extends GeneralException {
+    public UserHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/be/apiPayload/exception/tokenException/TokenErrorResult.java
+++ b/src/main/java/com/example/be/apiPayload/exception/tokenException/TokenErrorResult.java
@@ -1,0 +1,39 @@
+package com.example.be.apiPayload.exception.tokenException;
+
+
+import com.example.be.apiPayload.code.BaseErrorCode;
+import com.example.be.apiPayload.code.ErrorReasonDTO;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TokenErrorResult implements BaseErrorCode {
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "401", "유효하지 않은 토큰입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "401", "유효하지 않은 액세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "401", "유효하지 않은 리프레쉬 토큰입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/example/be/apiPayload/exception/tokenException/TokenException.java
+++ b/src/main/java/com/example/be/apiPayload/exception/tokenException/TokenException.java
@@ -1,0 +1,15 @@
+package com.example.be.apiPayload.exception.tokenException;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenException extends RuntimeException {
+    private final TokenErrorResult tokenErrorResult;
+
+    @Override
+    public String getMessage() {
+        return tokenErrorResult.getMessage();
+    }
+}

--- a/src/main/java/com/example/be/config/SecurityConfig.java
+++ b/src/main/java/com/example/be/config/SecurityConfig.java
@@ -1,0 +1,73 @@
+package com.example.be.config;
+
+
+
+import com.example.be.apiPayload.exception.handler.OAuthLoginFailureHandler;
+import com.example.be.apiPayload.exception.handler.OAuthLoginSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
+    private final OAuthLoginFailureHandler oAuthLoginFailureHandler;
+
+    // CORS 설정
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(
+                "https://pharmquest.store",  // 프론트엔드 도메인
+                "https://api.pharmquest.store",// 백엔드 서브도메인
+                "http://localhost:8080",
+                "http://localhost:3000"
+        ));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.
+                httpBasic(HttpBasicConfigurer::disable)
+                .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource())) // CORS 설정 추가
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize ->
+                        authorize
+                                .requestMatchers("/**").permitAll()
+                )
+
+                .oauth2Login(oauth -> // OAuth2 로그인 기능에 대한 여러 설정의 진입점
+                        oauth
+                                .successHandler(oAuthLoginSuccessHandler) // 로그인 성공 시 핸들러
+                                .failureHandler(oAuthLoginFailureHandler) // 로그인 실패 시 핸들러
+                );
+
+        return httpSecurity.build();
+    }
+
+
+
+}

--- a/src/main/java/com/example/be/config/SwaggerConfig.java
+++ b/src/main/java/com/example/be/config/SwaggerConfig.java
@@ -1,0 +1,50 @@
+package com.example.be.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI api() {
+        SecurityScheme apiKey = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization")
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Bearer Token");
+
+        List<Server> servers = new ArrayList<>();
+        if (isLocalEnvironment()) {
+            servers.add(new Server().url("http://localhost:8080").description("Local Server"));
+        }
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Study Link API")
+                        .version("1.0")
+                        .description("Study Link 프로젝트 API 문서"))
+                .servers(servers)
+                .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+                .addSecurityItem(securityRequirement);
+    }
+
+    private boolean isLocalEnvironment() {
+        String env = System.getProperty("spring.profiles.active", "local");
+        return "local".equals(env);
+    }
+
+}

--- a/src/main/java/com/example/be/config/provider/GoogleUserInfo.java
+++ b/src/main/java/com/example/be/config/provider/GoogleUserInfo.java
@@ -1,0 +1,33 @@
+package com.example.be.config.provider;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes; //oauth2User.getAttributes()
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+}

--- a/src/main/java/com/example/be/config/provider/KakaoUserInfo.java
+++ b/src/main/java/com/example/be/config/provider/KakaoUserInfo.java
@@ -1,0 +1,50 @@
+package com.example.be.config.provider;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements OAuth2UserInfo{
+    private Map<String, Object> attributes;
+    private Map<String, Object> attributesAccount;
+    private Map<String, Object> attributesProfile;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        /*
+        System.out.println(attributes);
+            {id=아이디값,
+            connected_at=2022-02-22T15:50:21Z,
+            properties={nickname=이름},
+            kakao_account={
+                profile_nickname_needs_agreement=false,
+                profile={nickname=이름},
+                has_email=true,
+                email_needs_agreement=false,
+                is_email_valid=true,
+                is_email_verified=true,
+                email=이메일}
+            }
+        */
+        this.attributes = attributes;
+        this.attributesAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.attributesProfile = (Map<String, Object>) attributesAccount.get("profile");
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getProvider() {
+        return "Kakao";
+    }
+
+    @Override
+    public String getEmail() {
+        return attributesAccount.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attributesProfile.get("nickname").toString();
+    }
+}

--- a/src/main/java/com/example/be/config/provider/NaverUserInfo.java
+++ b/src/main/java/com/example/be/config/provider/NaverUserInfo.java
@@ -1,0 +1,32 @@
+package com.example.be.config.provider;
+
+import java.util.Map;
+
+public class NaverUserInfo implements OAuth2UserInfo {
+    private final Map<String, Object> attributes; //oauth2User.getAttributes()
+
+    public NaverUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("id");
+    }
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+}

--- a/src/main/java/com/example/be/config/provider/OAuth2UserInfo.java
+++ b/src/main/java/com/example/be/config/provider/OAuth2UserInfo.java
@@ -1,0 +1,8 @@
+package com.example.be.config.provider;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getProvider();
+    String getEmail();
+    String getName();
+}

--- a/src/main/java/com/example/be/domain/RefreshToken.java
+++ b/src/main/java/com/example/be/domain/RefreshToken.java
@@ -1,0 +1,25 @@
+package com.example.be.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_tokens_id")
+    private Long id;
+
+    @Column(name = "users_uuid", columnDefinition = "BINARY(16)", unique = true)
+    private UUID userId;
+
+    @Column(name = "token", nullable = false)
+    private String token;
+}

--- a/src/main/java/com/example/be/domain/Room.java
+++ b/src/main/java/com/example/be/domain/Room.java
@@ -27,6 +27,10 @@ public class Room {
 
     private String password;
 
+    private String roomImage;
+
+    private String maxParticipants;
+
     private Long participantCount;
 
     private LocalDateTime createDate;

--- a/src/main/java/com/example/be/domain/User.java
+++ b/src/main/java/com/example/be/domain/User.java
@@ -3,9 +3,6 @@ package com.example.be.domain;
 import com.example.be.domain.enums.LoginType;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -25,13 +22,15 @@ public class User {
     @Column(nullable = false)
     private String name;
 
+    private UUID userId;
+
+
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Column(nullable = false)
     private String password;
 
-    private LoginType loginType;
+    private String provider;
 
     private String providerId;
 

--- a/src/main/java/com/example/be/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/be/repository/RefreshTokenRepository.java
@@ -1,0 +1,21 @@
+package com.example.be.repository;
+
+import com.example.be.domain.RefreshToken;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken,Long> {
+    @Query("SELECT u FROM RefreshToken u WHERE u.userId = :userId")
+    RefreshToken findByUserId(UUID userId);
+
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM RefreshToken u WHERE u.userId = :userId")
+    void deleteByUserId(UUID userId);
+}

--- a/src/main/java/com/example/be/repository/UserRepository.java
+++ b/src/main/java/com/example/be/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package com.example.be.repository;
+
+import com.example.be.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    User findNameById(Long id);
+
+    @Query("SELECT u FROM User u WHERE u.userId = :userId")
+    Optional<User> findByUserId(UUID userId);
+
+    User findByProviderId(String providerId);
+}

--- a/src/main/java/com/example/be/service/JwtUtilServiceImpl.java
+++ b/src/main/java/com/example/be/service/JwtUtilServiceImpl.java
@@ -1,0 +1,111 @@
+package com.example.be.service;
+
+
+
+import com.example.be.apiPayload.code.status.ErrorStatus;
+import com.example.be.apiPayload.exception.handler.UserHandler;
+import com.example.be.apiPayload.exception.tokenException.TokenErrorResult;
+import com.example.be.apiPayload.exception.tokenException.TokenException;
+import com.example.be.domain.User;
+import com.example.be.repository.UserRepository;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtilServiceImpl {
+    @Value("${jwt.secret}")
+    private String SECRET_KEY;
+    private final UserRepository userRepository;
+
+    private SecretKey getSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(this.SECRET_KEY);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // 액세스 토큰을 발급하는 메서드
+    public String generateAccessToken(UUID userId, long expirationMillis) {
+        log.info("액세스 토큰이 발행되었습니다.");
+
+        return Jwts.builder()
+                .claim("userId", userId.toString()) // 클레임에 userId 추가
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationMillis))
+                .signWith(this.getSigningKey())
+                .compact();
+    }
+
+    // 리프레쉬 토큰을 발급하는 메서드
+    public String generateRefreshToken(UUID userId, long expirationMillis) {
+        log.info("리프레쉬 토큰이 발행되었습니다.");
+
+        return Jwts.builder()
+                .claim("userId", userId.toString()) // 클레임에 userId 추가
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationMillis))
+                .signWith(this.getSigningKey())
+                .compact();
+    }
+
+    // 응답 헤더에서 액세스 토큰을 반환하는 메서드
+    public String getTokenFromHeader(String authorizationHeader) {
+        return authorizationHeader.substring(7);
+    }
+
+    // 토큰에서 유저 id를 반환하는 메서드
+    public String getUserIdFromToken(String token) {
+        try {
+            String userId = Jwts.parser()
+                    .verifyWith(this.getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get("userId", String.class);
+            log.info("유저 id를 반환합니다.");
+            return userId;
+        } catch (JwtException | IllegalArgumentException e) {
+            // 토큰이 유효하지 않은 경우
+            log.warn("유효하지 않은 토큰입니다.");
+            throw new TokenException(TokenErrorResult.INVALID_TOKEN);
+        }
+    }
+
+    // 토큰에서 유저를 반환하는 메서드
+    public User getUserFromHeader(String authorizationHeader) {
+        String token = getTokenFromHeader(authorizationHeader);
+        log.info("token:" + token);
+        UUID userId = UUID.fromString(getUserIdFromToken(token));
+
+        return userRepository.findByUserId(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus._NOT_FOUND_USER));
+    }
+
+    // Jwt 토큰의 유효기간을 확인하는 메서드
+    public boolean isTokenExpired(String token) {
+        try {
+            Date expirationDate = Jwts.parser()
+                    .verifyWith(this.getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getExpiration();
+            log.info("토큰의 유효기간을 확인합니다.");
+            return expirationDate.before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            // 토큰이 유효하지 않은 경우
+            log.warn("유효하지 않은 토큰입니다.");
+            throw new TokenException(TokenErrorResult.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/example/be/service/TokenServiceImpl.java
+++ b/src/main/java/com/example/be/service/TokenServiceImpl.java
@@ -1,0 +1,43 @@
+package com.example.be.service;
+
+
+import com.example.be.apiPayload.exception.tokenException.TokenErrorResult;
+import com.example.be.apiPayload.exception.tokenException.TokenException;
+import com.example.be.domain.RefreshToken;
+import com.example.be.repository.RefreshTokenRepository;
+import com.example.be.web.dto.TokenResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.token.TokenService;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TokenServiceImpl{
+    @Value("${jwt.access-token.expiration-time}")
+    private long ACCESS_TOKEN_EXPIRATION_TIME; // 액세스 토큰 유효기간
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtUtilServiceImpl jwtUtil;
+
+    public TokenResponseDTO reissueAccessToken(String authorizationHeader) {
+        String refreshToken = jwtUtil.getTokenFromHeader(authorizationHeader);
+        String userId = jwtUtil.getUserIdFromToken(refreshToken);
+        RefreshToken existRefreshToken = refreshTokenRepository.findByUserId(UUID.fromString(userId));
+        String accessToken = null;
+
+        if (!existRefreshToken.getToken().equals(refreshToken) || jwtUtil.isTokenExpired(refreshToken)) {
+            // 리프레쉬 토큰이 다르거나, 만료된 경우
+            throw new TokenException(TokenErrorResult.INVALID_REFRESH_TOKEN); // 401 에러를 던져 재로그인을 요청
+        } else {
+            // 액세스 토큰 재발급
+            accessToken = jwtUtil.generateAccessToken(UUID.fromString(userId), ACCESS_TOKEN_EXPIRATION_TIME);
+        }
+
+        return TokenResponseDTO.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/example/be/web/controller/LoginController.java
+++ b/src/main/java/com/example/be/web/controller/LoginController.java
@@ -1,0 +1,22 @@
+package com.example.be.web.controller;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Hidden
+@RestController
+public class LoginController {
+
+    @GetMapping("/login")
+    public ResponseEntity<?> handleLoginRedirect(
+            @RequestParam String name,
+            @RequestParam String access_token,
+            @RequestParam String refresh_token) {
+
+        return ResponseEntity.ok("로그인 성공");
+    }
+
+}

--- a/src/main/java/com/example/be/web/controller/TokenController.java
+++ b/src/main/java/com/example/be/web/controller/TokenController.java
@@ -1,0 +1,36 @@
+package com.example.be.web.controller;
+
+
+import com.example.be.apiPayload.ApiResponse;
+import com.example.be.apiPayload.code.status.SuccessStatus;
+import com.example.be.service.TokenServiceImpl;
+import com.example.be.web.dto.TokenResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.token.TokenService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class TokenController {
+
+    private final TokenServiceImpl authService;
+
+
+    // 액세스 토큰을 재발행하는 API
+    @GetMapping("/reissue/access-token")
+    @Operation(summary = "액세스 토큰 재발행 API")
+    public ResponseEntity<ApiResponse<Object>> reissueAccessToken(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String authorizationHeader) {
+
+        TokenResponseDTO accessToken = authService.reissueAccessToken(authorizationHeader);
+        return ApiResponse.onSuccess(SuccessStatus._CREATED_ACCESS_TOKEN, accessToken);
+    }
+}

--- a/src/main/java/com/example/be/web/dto/TokenResponseDTO.java
+++ b/src/main/java/com/example/be/web/dto/TokenResponseDTO.java
@@ -1,0 +1,12 @@
+package com.example.be.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class TokenResponseDTO {
+    @JsonProperty("access_token")
+    private String accessToken;
+}

--- a/src/main/java/com/example/be/web/dto/UserDTO.java
+++ b/src/main/java/com/example/be/web/dto/UserDTO.java
@@ -1,0 +1,21 @@
+package com.example.be.web.dto;
+
+import com.example.be.domain.enums.LoginType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserResponseDto {
+        private Long userId;
+        private String userName;
+        private LoginType loginType;
+        private String email;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,47 @@ spring:
     username: ${SQL_DB_USERNAME}
     password: ${SQL_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope:
+              - email
+              - profile
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            scope:
+              - name
+              - email
+            client-name: Naver
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            client-name: Kakao
+            scope:
+              - profile_nickname
+              - account_email
+
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response #회원정보를 json으로 받는데 response라는 키값으로 네이버가 리턴해준다.
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
   jpa:
     hibernate:
       ddl-auto: update
@@ -14,3 +55,11 @@ spring:
         format_sql: true
         default_batch_fetch_size: 1000
     database-platform: org.hibernate.dialect.MySQL8Dialect
+
+jwt:
+  secret: ${JWT_SECRET} #64글자 이상의 영어 알파벳으로 이루어진 값으로 사용
+  redirect: http://localhost:8080/login?name=%s&access_token=%s&refresh_token=%s # 소셜 로그인 성공 이후 프론트엔드 측으로 보내줄 리다이렉트 URI
+  access-token:
+    expiration-time: 3600000 #액세스 토큰의 유효기간
+  refresh-token:
+    expiration-time: 604800000 #리프레쉬 토큰의 유효기간


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1 

## 📝작업 내용

> 소셜 로그인을 구현하였습니다. 현재 로컬 환경에서 작업중이라 redirect URL은 localhost로 설정해두었으며 추후에 배포 후 변경된 도메인으로 사용할 예정입니다. 또한 로그인이 프론트와 연동하는 방식이 url의 쿼리에 jwt 토큰값을 두어서(클라이언트 화면엔 나타나지 않는 url) 프론트가 해당 jwt 토큰을 가져가는 방식으로 되어있는데, 쿠키를 사용하여 보안성을 높일 예정입니다. (일반 로그인 구현 후 작업 예정)

### 스크린샷 (선택)
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/79efa771-8b6a-46f8-81df-f91e872b1aff" />
<img width="669" alt="image" src="https://github.com/user-attachments/assets/f0964b44-6501-43d9-b666-b4895a1f809d" />
