### PR TITLE
[FEAT] #13 openvidu 기본 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,10 @@ dependencies {
     // Deploy Health-Check
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    //Openvidu
+    implementation 'io.livekit:livekit-server:0.9.0'
+
+
 }
 
 test {

--- a/src/main/java/com/example/be/web/controller/OpenviduController.java
+++ b/src/main/java/com/example/be/web/controller/OpenviduController.java
@@ -1,0 +1,55 @@
+package com.example.be.web.controller;
+
+import com.example.be.web.dto.OpenviduDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+import io.livekit.server.AccessToken;
+import io.livekit.server.RoomJoin;
+import io.livekit.server.RoomName;
+import io.livekit.server.WebhookReceiver;
+import livekit.LivekitWebhook.WebhookEvent;
+
+@CrossOrigin(origins = "*")
+@RestController
+public class OpenviduController {
+
+    @Value("${livekit.api.key}")
+    private String LIVEKIT_API_KEY;
+
+    @Value("${livekit.api.secret}")
+    private String LIVEKIT_API_SECRET;
+
+
+    @PostMapping(value = "/token")
+    public ResponseEntity<Map<String, String>> createToken(@RequestBody OpenviduDTO.TokenRequestDto request) {
+        String roomName = request.getRoomName();
+        String participantName = request.getParticipantName();
+
+        if (roomName == null || participantName == null) {
+            return ResponseEntity.badRequest().body(Map.of("errorMessage", "roomName and participantName are required"));
+        }
+
+        AccessToken token = new AccessToken(LIVEKIT_API_KEY, LIVEKIT_API_SECRET);
+        token.setName(participantName);
+        token.setIdentity(participantName);
+        token.addGrants(new RoomJoin(true), new RoomName(roomName));
+
+        return ResponseEntity.ok(Map.of("token", token.toJwt()));
+    }
+
+    @PostMapping(value = "/livekit/webhook", consumes = "application/webhook+json")
+    public ResponseEntity<String> receiveWebhook(@RequestHeader("Authorization") String authHeader, @RequestBody String body) {
+        WebhookReceiver webhookReceiver = new WebhookReceiver(LIVEKIT_API_KEY, LIVEKIT_API_SECRET);
+        try {
+            WebhookEvent event = webhookReceiver.receive(body, authHeader);
+            System.out.println("LiveKit Webhook: " + event.toString());
+        } catch (Exception e) {
+            System.err.println("Error validating webhook event: " + e.getMessage());
+        }
+        return ResponseEntity.ok("ok");
+    }
+}

--- a/src/main/java/com/example/be/web/dto/OpenviduDTO.java
+++ b/src/main/java/com/example/be/web/dto/OpenviduDTO.java
@@ -1,0 +1,18 @@
+package com.example.be.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class OpenviduDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TokenRequestDto {
+        private String roomName;
+        private String participantName;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,3 +77,8 @@ server:
   protocol: https
   host: 8080
   port: 8081
+
+livekit:
+  api:
+    key: ${LIVEKIT_API_KEY}
+    secret: ${LIVEKIT_API_SECRET}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #13 

## 📝작업 내용

> openvidu에 사용되는 createToken(), receiveWebhook() 메서드를 구현하였습니다.
createToken()은 클라이언트 측에서 사용자 이름과 방 이름을 보내면, 그에 맞는 방을 사용자의 이름으로 연동시켜주는 기능입니다.
receiveWebhook()은 LiveKit이 제공하는 이벤트 웹훅을 수신하여 Openvidu서버에 이벤트를 처리하는 기능입니다.

