### PR TITLE
[FEAT] #21 게시글 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/be/repository/PostRepository.java
+++ b/src/main/java/com/example/be/repository/PostRepository.java
@@ -1,7 +1,14 @@
 package com.example.be.repository;
 
 import com.example.be.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-}
+    // PostRepository에 추가
+    @Query("SELECT p FROM Post p LEFT JOIN FETCH p.comments ORDER BY p.createDate DESC")
+    Page<Post> findAllWithCommentsOrderByCreateDateDesc(Pageable pageable);}

--- a/src/main/java/com/example/be/web/controller/PostController.java
+++ b/src/main/java/com/example/be/web/controller/PostController.java
@@ -11,9 +11,12 @@ import com.example.be.web.dto.CommonDTO;
 import com.example.be.web.dto.PostDTO;
 import com.example.be.web.dto.UserDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/post")
@@ -28,5 +31,13 @@ public class PostController {
 
         return ApiResponse.onSuccess(postService.write(request, req));
     }
+
+    @GetMapping("/list")
+    @Operation(summary = "게시글 목록 조회 API (페이지네이션)", description = "15개씩 페이지네이션하여 게시글 목록을 조회합니다.")
+    public ApiResponse<PostDTO.PageResponseDTO> getPosts(
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page) {
+        return ApiResponse.onSuccess(postService.getPosts(page, 4)); // 4개씩 페이지네이션
+    }
+
 
 }

--- a/src/main/java/com/example/be/web/dto/PostDTO.java
+++ b/src/main/java/com/example/be/web/dto/PostDTO.java
@@ -1,5 +1,6 @@
 package com.example.be.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 
@@ -25,17 +27,27 @@ public class PostDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class postResponseDTO {
+        Long id;
         String title;
         String content;
-        String user;
-        LocalDate date;
+        String userName;
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate createDate;
+        int commentCount;
+        boolean isDone;
     }
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class postListResponseDTO{
-        List<postResponseDTO> postList;
+    @Schema(description = "게시글 페이지네이션 응답 DTO")
+    public static class PageResponseDTO {
+        private List<postResponseDTO> posts;
+        private int currentPage;
+        private int totalPages;
+        private long totalElements;
+        private boolean first;
+        private boolean last;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21 

## 📝작업 내용

> 페이지 요청을 받아 4개씩 페이지네이션하여 게시글을 리스트 형식으로 반환합니다.

<img width="351" alt="image" src="https://github.com/user-attachments/assets/4301319c-cc98-4791-83ec-22585e09d770" />
