### PR TITLE
[FEAT] #25 댓글 작성 기능 구현

### DIFF
--- a/src/main/java/com/example/be/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/be/apiPayload/code/status/ErrorStatus.java
@@ -25,8 +25,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _NOT_FOUND_COOKIE(HttpStatus.NOT_FOUND, "USER403", "쿠키가 없습니다."),
 
     //게시글 관련 에러
-    _NOT_FOUND_POST(HttpStatus.NOT_FOUND, "POST401", "해당 게시글을 찾을 수 없습니다.");
+    _NOT_FOUND_POST(HttpStatus.NOT_FOUND, "POST401", "해당 게시글을 찾을 수 없습니다."),
 
+    //댓글 관련 에러
+    _NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, "COMMENT404", "해당 댓글을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/be/repository/CommentRepository.java
+++ b/src/main/java/com/example/be/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.example.be.repository;
+
+import com.example.be.domain.Comment;
+import com.example.be.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/example/be/service/CommentServiceImpl.java
+++ b/src/main/java/com/example/be/service/CommentServiceImpl.java
@@ -1,0 +1,66 @@
+package com.example.be.service;
+
+import com.example.be.apiPayload.code.status.ErrorStatus;
+import com.example.be.apiPayload.exception.handler.UserHandler;
+import com.example.be.domain.Comment;
+import com.example.be.domain.Post;
+import com.example.be.domain.User;
+import com.example.be.repository.CommentRepository;
+import com.example.be.repository.PostRepository;
+import com.example.be.repository.UserRepository;
+import com.example.be.web.dto.CommentDTO;
+import com.example.be.web.dto.CommonDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl {
+
+    private final JwtUtilServiceImpl jwtUtilService;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public CommonDTO.IsSuccessDTO createComment(CommentDTO.CommentRequestDTO requestDTO, HttpServletRequest request) {
+        String accessToken = jwtUtilService.extractTokenFromCookie(request, "accessToken");
+        if (accessToken == null) {
+            throw new UserHandler(ErrorStatus._NOT_FOUND_USER);
+        }
+
+        String userId = jwtUtilService.getUserIdFromToken(accessToken);
+        User user = userRepository.findByUserId(UUID.fromString(userId))
+                .orElseThrow(() -> new UserHandler(ErrorStatus._NOT_FOUND_USER));
+
+        Post post = postRepository.findById(requestDTO.getPostId())
+                .orElseThrow(() -> new UserHandler(ErrorStatus._NOT_FOUND_POST));
+
+        Comment comment = Comment.builder()
+                .comment(requestDTO.getComment())
+                .createDate(LocalDateTime.now())
+                .user(user)
+                .post(post)
+                .build();
+
+        // 대댓글인 경우 상위 댓글 설정
+        if (requestDTO.getParentCommentId() != null) {
+            Comment parentComment = commentRepository.findById(requestDTO.getParentCommentId())
+                    .orElseThrow(() -> new RuntimeException("상위 댓글을 찾을 수 없습니다."));
+
+            if (parentComment.getTopParent() != null) {
+                comment.setTopParent(parentComment.getTopParent());
+            } else {
+                comment.setTopParent(parentComment);
+            }
+        }
+
+        commentRepository.save(comment);
+        return CommonDTO.IsSuccessDTO.builder().isSuccess(true).build();
+    }
+}

--- a/src/main/java/com/example/be/web/controller/CommentController.java
+++ b/src/main/java/com/example/be/web/controller/CommentController.java
@@ -1,0 +1,30 @@
+package com.example.be.web.controller;
+
+import com.example.be.apiPayload.ApiResponse;
+import com.example.be.service.CommentServiceImpl;
+import com.example.be.service.PostServiceImpl;
+import com.example.be.web.dto.CommentDTO;
+import com.example.be.web.dto.CommonDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/comment")
+@RequiredArgsConstructor
+public class CommentController {
+    private final PostServiceImpl postService;
+    private final CommentServiceImpl commentService;
+
+    @PostMapping("")
+    @Operation(summary = "댓글 작성 API", description = "게시글에 댓글을 작성하거나 다른 댓글에 대한 답글을 작성합니다.")
+    public ApiResponse<CommonDTO.IsSuccessDTO> createComment(
+            @RequestBody CommentDTO.CommentRequestDTO requestDTO,
+            HttpServletRequest request) {
+        return ApiResponse.onSuccess(commentService.createComment(requestDTO, request));
+    }
+}

--- a/src/main/java/com/example/be/web/dto/CommentDTO.java
+++ b/src/main/java/com/example/be/web/dto/CommentDTO.java
@@ -1,0 +1,21 @@
+package com.example.be.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CommentDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "댓글 작성 요청 DTO")
+    public static class CommentRequestDTO {
+        private String comment;
+        private Long postId;
+        private Long parentCommentId;
+    }
+}

--- a/src/main/java/com/example/be/web/dto/PostDTO.java
+++ b/src/main/java/com/example/be/web/dto/PostDTO.java
@@ -86,4 +86,6 @@ public class PostDTO {
         private int commentCount;
         private List<CommentResponseDTO> comments;
     }
+
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용

댓글과 대댓글을 구분하여 db에 저장시킵니다. 상위 부모 댓글이 없을 시 null로 처리하며, 대댓글일 경우 상위 댓글의 댓글 id를 request로 받아 저장시킵니다.

<img width="1055" alt="image" src="https://github.com/user-attachments/assets/5832f2bd-6deb-4619-afaa-63d0258ae646" />
