### PR TITLE
[FEAT] #31 스터디룸 목록 조회 api 구현

### DIFF
--- a/src/main/java/com/example/be/config/LiveKitConfig.java
+++ b/src/main/java/com/example/be/config/LiveKitConfig.java
@@ -1,0 +1,28 @@
+package com.example.be.config;
+
+import io.livekit.server.RoomServiceClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LiveKitConfig {
+
+    @Value("${livekit.api.key}")
+    private String LIVEKIT_API_KEY;
+
+    @Value("${livekit.api.secret}")
+    private String LIVEKIT_API_SECRET;
+
+    @Value("${livekit.api.host}")
+    private String LIVEKIT_API_HOST;
+
+    @Bean
+    public RoomServiceClient roomServiceClient() {
+        return RoomServiceClient.create(
+                LIVEKIT_API_HOST,
+                LIVEKIT_API_KEY,
+                LIVEKIT_API_SECRET
+        );
+    }
+}

--- a/src/main/java/com/example/be/service/RoomServiceImpl.java
+++ b/src/main/java/com/example/be/service/RoomServiceImpl.java
@@ -1,0 +1,59 @@
+package com.example.be.service;
+
+import com.example.be.web.dto.RoomDTO;
+import io.livekit.server.RoomService;
+import io.livekit.server.RoomServiceClient;
+import livekit.LivekitModels;
+import livekit.LivekitRoom;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoomServiceImpl {
+    private final RoomServiceClient roomServiceClient;
+
+    public RoomDTO.RoomListResponseDto getAllRooms() {
+        try {
+            Call<List<LivekitModels.Room>> call = roomServiceClient.listRooms();
+            Response<List<LivekitModels.Room>> response = call.execute();
+
+            if (!response.isSuccessful()) {
+                throw new RuntimeException("Failed to fetch rooms: " + response.errorBody().string());
+            }
+
+            List<LivekitModels.Room> rooms = response.body();
+            List<RoomDTO.RoomDto> roomDtos = rooms.stream()
+                    .map(this::convertToDto)
+                    .collect(Collectors.toList());
+
+            return RoomDTO.RoomListResponseDto.builder()
+                    .rooms(roomDtos)
+                    .totalCount(roomDtos.size())
+                    .build();
+        } catch (IOException e) {
+            log.error("Failed to fetch rooms from LiveKit", e);
+            throw new RuntimeException("Failed to fetch rooms from LiveKit", e);
+        }
+    }
+
+
+    private RoomDTO.RoomDto convertToDto(LivekitModels.Room room) {
+        return RoomDTO.RoomDto.builder()
+                .sid(room.getSid())
+                .name(room.getName())
+                .creationTime(room.getCreationTime())
+                .numParticipants(room.getNumParticipants())
+                .maxParticipants(room.getMaxParticipants())
+                .metadata(room.getMetadata())
+                .build();
+    }
+}

--- a/src/main/java/com/example/be/web/controller/RoomController.java
+++ b/src/main/java/com/example/be/web/controller/RoomController.java
@@ -1,0 +1,43 @@
+package com.example.be.web.controller;
+
+
+import com.example.be.apiPayload.ApiResponse;
+import com.example.be.service.RoomServiceImpl;
+import com.example.be.web.dto.RoomDTO;
+import io.livekit.server.AccessToken;
+import io.livekit.server.RoomJoin;
+import io.livekit.server.RoomList;
+import io.livekit.server.VideoGrant;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+@RequestMapping("/room")
+@RequiredArgsConstructor
+public class RoomController {
+    private final RoomServiceImpl roomService;
+
+
+    @GetMapping("/rooms")
+    @Operation(summary = "방 목록 조회", description = "생성된 모든 방 목록을 조회합니다.")
+    public ApiResponse<RoomDTO.RoomListResponseDto> getAllRooms() {
+//
+//        AccessToken accessToken = new AccessToken(LIVEKIT_API_KEY, LIVEKIT_API_SECRET);
+//
+//        // Grant 설정
+//        RoomList roomList = new RoomList(true);
+//        accessToken.addGrants(roomList);
+//
+//        String jwt = accessToken.toJwt();
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.add("Authorization", "Bearer " + jwt);
+
+        return ApiResponse.onSuccess(roomService.getAllRooms());
+    }
+}

--- a/src/main/java/com/example/be/web/dto/ParticipantDTO.java
+++ b/src/main/java/com/example/be/web/dto/ParticipantDTO.java
@@ -1,0 +1,21 @@
+package com.example.be.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ParticipantDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ParticipantDto {
+        private String sid;
+        private String identity;
+        private String name;
+        private String metadata;
+        private long joinedAt;
+    }
+}

--- a/src/main/java/com/example/be/web/dto/RoomDTO.java
+++ b/src/main/java/com/example/be/web/dto/RoomDTO.java
@@ -1,0 +1,43 @@
+package com.example.be.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class RoomDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RoomDto {
+        private String sid;
+        private String name;
+        private long creationTime;
+        private int numParticipants;
+        private int maxParticipants;
+        private String metadata;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateRoomRequestDto {
+        private String roomName;
+        private Integer maxParticipants;
+        private String metadata;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RoomListResponseDto {
+        private List<RoomDto> rooms;
+        private int totalCount;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,5 +78,6 @@ server:
 
 livekit:
   api:
+    host: ${LIVEKIT_API_HOST}
     key: ${LIVEKIT_API_KEY}
     secret: ${LIVEKIT_API_SECRET}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #31 

## 📝작업 내용

> LiveKit API를 사용하여 스터디룸의 목록을 조회하고 프론트측으로 반환합니다.
현재 로컬환경에서는 실행이 어려워, 배포환경에서 테스트 진행 후 수정할 예정입니다.
