### PR TITLE
[FEAT] #42 livekit 웹훅 수신 후 데이터베이스에 저장 로직 구현

### DIFF
--- a/src/main/java/com/example/be/domain/Room.java
+++ b/src/main/java/com/example/be/domain/Room.java
@@ -31,9 +31,9 @@ public class Room {
 
     private String maxParticipants;
 
-    private Long participantCount;
+    private int participantCount;
 
-    private LocalDateTime createDate;
+    private long createDate;
 
 
     //Relationships

--- a/src/main/java/com/example/be/repository/RoomRepository.java
+++ b/src/main/java/com/example/be/repository/RoomRepository.java
@@ -1,0 +1,9 @@
+package com.example.be.repository;
+
+import com.example.be.domain.RefreshToken;
+import com.example.be.domain.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room,Long> {
+    Room findByTitle(String title);
+}

--- a/src/main/java/com/example/be/web/controller/OpenviduController.java
+++ b/src/main/java/com/example/be/web/controller/OpenviduController.java
@@ -1,7 +1,10 @@
 package com.example.be.web.controller;
 
+import com.example.be.domain.Room;
+import com.example.be.repository.RoomRepository;
 import com.example.be.web.dto.OpenviduDTO;
 import io.livekit.server.*;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +16,7 @@ import livekit.LivekitWebhook.WebhookEvent;
 @CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/api/v1/video")
+@RequiredArgsConstructor
 public class OpenviduController {
 
     @Value("${livekit.api.key}")
@@ -20,6 +24,8 @@ public class OpenviduController {
 
     @Value("${livekit.api.secret}")
     private String LIVEKIT_API_SECRET;
+
+    private final RoomRepository roomRepository;
 
 
     @PostMapping(value = "/token")
@@ -44,7 +50,29 @@ public class OpenviduController {
         WebhookReceiver webhookReceiver = new WebhookReceiver(LIVEKIT_API_KEY, LIVEKIT_API_SECRET);
         try {
             WebhookEvent event = webhookReceiver.receive(body, authHeader);
+            String roomName = event.getRoom().getName();
+            Room room = roomRepository.findByTitle(roomName);
+            long createAt = event.getRoom().getCreationTime();
             System.out.println("LiveKit Webhook: " + event.toString());
+
+            switch (event.toString()) {
+                case "room_started" -> {
+                    room = Room.builder()
+                            .title(roomName)
+                            .createDate(createAt)
+                            .build();
+                    roomRepository.save(room);
+                }
+                case "room_finished" -> roomRepository.delete(room);
+                case "participant_joined" -> {
+                    room.setParticipantCount(room.getParticipantCount() + 1);
+                    roomRepository.save(room);
+                }
+                case "participant_left" -> {
+                    room.setParticipantCount(room.getParticipantCount() - 1);
+                    roomRepository.save(room);
+                }
+            }
         } catch (Exception e) {
             System.err.println("Error validating webhook event: " + e.getMessage());
         }

--- a/src/main/java/com/example/be/web/controller/RoomController.java
+++ b/src/main/java/com/example/be/web/controller/RoomController.java
@@ -27,16 +27,6 @@ public class RoomController {
     @GetMapping("/rooms")
     @Operation(summary = "방 목록 조회", description = "생성된 모든 방 목록을 조회합니다.")
     public ApiResponse<RoomDTO.RoomListResponseDto> getAllRooms() {
-//
-//        AccessToken accessToken = new AccessToken(LIVEKIT_API_KEY, LIVEKIT_API_SECRET);
-//
-//        // Grant 설정
-//        RoomList roomList = new RoomList(true);
-//        accessToken.addGrants(roomList);
-//
-//        String jwt = accessToken.toJwt();
-//        HttpHeaders headers = new HttpHeaders();
-//        headers.add("Authorization", "Bearer " + jwt);
 
         return ApiResponse.onSuccess(roomService.getAllRooms());
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #42 

## 📝작업 내용

            WebhookEvent event = webhookReceiver.receive(body, authHeader);
            String roomName = event.getRoom().getName();
            Room room = roomRepository.findByTitle(roomName);
            long createAt = event.getRoom().getCreationTime();
            System.out.println("LiveKit Webhook: " + event.toString());

            switch (event.toString()) {
                case "room_started" -> {
                    room = Room.builder()
                            .title(roomName)
                            .createDate(createAt)
                            .build();
                    roomRepository.save(room);
                }
                case "room_finished" -> roomRepository.delete(room);
                case "participant_joined" -> {
                    room.setParticipantCount(room.getParticipantCount() + 1);
                    roomRepository.save(room);
                }
                case "participant_left" -> {
                    room.setParticipantCount(room.getParticipantCount() - 1);
                    roomRepository.save(room);
                }
            }
이벤트를 수신하여, 이벤트의 이름에 따라 데이터베이스에 방을 생성하고, 참가자를 더하고 빼고, 방을 삭제하는 로직을 추가하였습니다.

